### PR TITLE
Fix minor issues in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The sigutils library is a digital signal processing library written in C, designed for blind signal analysis and automatic demodulation in GNU/Linux.
 
-## Requierements and dependencies
-sigutils has been tested in GNU/Linux (i386 and x86_64), but it will probably work in many other architectures as well. Autoconf (2.65 or later) and automake (1.11.1 or later) are required to build the library. The following librares (along with their respective development files) must also be present:
+## Requirements and dependencies
+sigutils has been tested in GNU/Linux (i386 and x86_64), but it will probably work in many other architectures as well. Autoconf (2.65 or later) and automake (1.11.1 or later) are required to build the library. The following libraries (along with their respective development files) must also be present:
 
 * libsndfile (1.0.2 or later)
 * alsa (1.0.25 or later)
@@ -44,7 +44,7 @@ In order to run all unit tests, you must download [this ZIP file](http://www.sig
 There are three API levels in sigutils, with every high-level API relying on lower-level APIs:
 
 1. Modem API (which allows to retrieve a stream of symbols from a given signal source)
-2. Block API (enables complex stream manipulation using functional blocks in a GNURadio-like fashion)
+2. Block API (enables complex stream manipulation using functional blocks in a GNU Radio-like fashion)
 3. DSP API (low-level API to manipulate samples individually, with things like PLLs, oscillators, etc)
 
 ## sigutils type foundation
@@ -104,10 +104,10 @@ if (!su_modem_set_source(modem, source_block)) {
 Modem parameters are configured through the `su_modem_set_*` methods. Although every modem can accept a different set of parameters, they generally use the same naming convention for equivalent parameters:
 
 ```
-su_modem_set_bool(modem, "abc", SU_FALSE); /* Automatic baudrate control */
+su_modem_set_bool(modem, "abc", SU_FALSE); /* Automatic baud rate control */
 su_modem_set_bool(modem, "afc", SU_TRUE); /* Automatic frequency control */
 su_modem_set_int(modem, "mf_span", 4); /* Matched filter span (in symbols) */
-su_modem_set_float(modem, "baud", 468); /* Baudrate: 468 bd */
+su_modem_set_float(modem, "baud", 468); /* Baud rate: 468 baud */
 su_modem_set_float(modem, "fc", 910); /* Carrier frequency: 910 Hz */
 su_modem_set_float(modem, "rolloff", .25); /* Roll-off factor of the matched filter */
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#The sigutils library - Getting started
+# The sigutils library - Getting started
 
 The sigutils library is a digital signal processing library written in C, designed for blind signal analysis and automatic demodulation in GNU/Linux.
 
@@ -40,7 +40,7 @@ In order to run all unit tests, you must download [this ZIP file](http://www.sig
 ```
 
 ---
-#sigutils API overview
+# sigutils API overview
 There are three API levels in sigutils, with every high-level API relying on lower-level APIs:
 
 1. Modem API (which allows to retrieve a stream of symbols from a given signal source)
@@ -64,7 +64,7 @@ Any other value is considered a valid symbol identifier.
 ## The modem API
 The core of the modem API is the `su_modem_t` object, which can be configured to retrieve discrete symbols from a variety of sources and modulations. Currently, only the QPSK modem, WAV file source and generic block source are implemented.
 
-###Creating a QPSK modem
+### Creating a QPSK modem
 Modems are created using the modem constructor `su_modem_new`, which accepts the class name of the specific modem to instantiate:
 
 ```
@@ -76,7 +76,7 @@ if ((modem = su_modem_new("qpsk")) == NULL) {
 }
 ```
 
-###Configuring the modem
+### Configuring the modem
 Once an appropriate modem type has been initialized, it must be configured before reading samples from it. Two actions are required to configure a modem: setting the signal source and setting modem parameters. If the signal source is a WAV file, this can be configured by calling `su_modem_set_wav_source`:
 
 ```
@@ -125,7 +125,7 @@ if (!su_modem_start(modem)) {
 
 This tells the modem to preallocate any parameter-dependent temporary data to start demodulation. Note that this method itself will not start demodulation. Demodulation happens in an *on demand* basis when a symbol read operation is requested. 
 
-###Reading symbols
+### Reading symbols
 After starting the modem, symbols can be read by looping over `su_modem_read`:
 
 ```
@@ -142,7 +142,7 @@ while((sym = su_modem_read(modem)) != SU_EOS) {
 
 Symbols are retrieved as an integer value, starting from 1. If the modem considers there is too much noise to make a good decision, it will return `SU_NOSYMBOL`. If the source cannot provide any more samples, `su_modem_read` will return `SU_EOS`.
 
-###Deleting the modem
+### Deleting the modem
 Once we are done using the modem object, it must be released using the `su_modem_destroy` method:
 
 ```


### PR DESCRIPTION
Thanks for sharing this great project. Here's some fixes for minor formatting and spelling mistakes in the README.md.

Separately, both README.md and README files exist. GitHub will display the README file if the .md one doesn't exist so they can be merged if you want. It would be a minor usability plus to have only one file.