### PR TITLE
fix the macOS g++ compile issues for _Complex

### DIFF
--- a/sigutils/types.h
+++ b/sigutils/types.h
@@ -29,6 +29,24 @@
 
 #include <util.h>
 
+#if defined(__cplusplus) && defined(__APPLE__)
+#  define SU_USE_CPP_COMPLEX_API
+#endif
+
+#ifndef I
+#define I std::complex<SUFLOAT>{0,1}
+#endif
+
+#ifdef SU_USE_CPP_COMPLEX_API
+#  define SUCOMPLEX  std::complex<SUFLOAT>
+#  define SU_C_REAL(c)  (c).real()
+#  define SU_C_IMAG(c)  (c).imag()
+#else
+#  define SUCOMPLEX  _Complex SUFLOAT
+#  define SU_C_REAL(c)   creal(c)
+#  define SU_C_IMAG(c)   cimag(c)
+#endif
+
 #ifdef _SU_SINGLE_PRECISION
 #  define SUFLOAT    float
 #  define SU_SOURCE_FFTW_PREFIX fftwf
@@ -42,7 +60,6 @@
 #define SUSDIFF    long
 #define SUBOOL     int
 #define SUFREQ     double
-#define SUCOMPLEX  _Complex SUFLOAT
 #define SUSYMBOL   int
 #define SUBITS     unsigned char /* Not exactly a bit */
 
@@ -103,8 +120,6 @@
 
 #define SU_C_ABS    SU_ADDSFX(cabs)
 #define SU_C_ARG    SU_ADDSFX(carg)
-#define SU_C_REAL   SU_ADDSFX(creal)
-#define SU_C_IMAG   SU_ADDSFX(cimag)
 #define SU_C_EXP    SU_ADDSFX(cexp)
 #define SU_C_CONJ   SU_ADDSFX(conj)
 #define SU_C_SGN(x) (SU_SGN(SU_C_REAL(x)) + I * SU_SGN(SU_C_IMAG(x)))

--- a/sigutils/types.h
+++ b/sigutils/types.h
@@ -41,10 +41,20 @@
 #  define SUCOMPLEX  std::complex<SUFLOAT>
 #  define SU_C_REAL(c)  (c).real()
 #  define SU_C_IMAG(c)  (c).imag()
+#  define SU_C_ABS(c)   std::abs(c)
+#  define SU_C_ARG(c)   std::arg(c)
+#  define SU_C_EXP(c)   std::exp(c)
+#  define SU_C_CONJ(c)	std::conj(c)
+#  define SU_C_SGN(x) SUCOMPLEX(SU_SGN(SU_C_REAL(x)), SU_SGN(SU_C_IMAG(x)))
 #else
 #  define SUCOMPLEX  _Complex SUFLOAT
 #  define SU_C_REAL(c)   creal(c)
 #  define SU_C_IMAG(c)   cimag(c)
+#  define SU_C_ABS    SU_ADDSFX(cabs)
+#  define SU_C_ARG    SU_ADDSFX(carg)
+#  define SU_C_EXP    SU_ADDSFX(cexp)
+#  define SU_C_CONJ   SU_ADDSFX(conj)
+#  define SU_C_SGN(x) (SU_SGN(SU_C_REAL(x)) + I * SU_SGN(SU_C_IMAG(x)))
 #endif
 
 #ifdef _SU_SINGLE_PRECISION
@@ -117,12 +127,6 @@
 #define SU_SINCOS SU_ADDSFX(sincos) /* May be unavailable, see config.h */
 
 #define SU_SGN(x) ((x) < 0 ? -1 : ((x) > 0 ? 1 : 0))
-
-#define SU_C_ABS    SU_ADDSFX(cabs)
-#define SU_C_ARG    SU_ADDSFX(carg)
-#define SU_C_EXP    SU_ADDSFX(cexp)
-#define SU_C_CONJ   SU_ADDSFX(conj)
-#define SU_C_SGN(x) (SU_SGN(SU_C_REAL(x)) + I * SU_SGN(SU_C_IMAG(x)))
 
 #ifndef PI
 #  define PI SU_ADDSFX(3.141592653589793238462643)


### PR DESCRIPTION
**WHAT**
This commit tries to fix the compile errors that happen on the default g++ compiler on macOS for _Complex and uses std::complex instead.
Basically it detects if we're on macOS and using C++ and then conditionally redefines some macros.

**WHY**
To be able to compile the code on macOS without resorting to non-default compilers (like the brew gcc)

**Links**
https://github.com/BatchDrake/sigutils/issues/8
https://stackoverflow.com/questions/10540228/c-complex-numbers-in-c