### PR TITLE
Revert "Use C++ complex API on all C++ builds, not just Apple builds"

### DIFF
--- a/sigutils/types.h
+++ b/sigutils/types.h
@@ -29,7 +29,7 @@
 
 #include <util.h>
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) && defined(__APPLE__)
 #  define SU_USE_CPP_COMPLEX_API
 #endif
 


### PR DESCRIPTION
Reverts BatchDrake/sigutils#19