### PR TITLE
WIP: CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,20 +44,23 @@ include(CodeAnalysis)
 find_package(Threads)
 pkg_check_modules(SNDFILE REQUIRED sndfile>=1.0.2)
 pkg_check_modules(FFTW3   REQUIRED fftw3f>=3.0)
-pkg_check_modules(VOLK              volk>=1.0)
+pkg_check_modules(VOLK             volk>=1.0)
 if(VOLK_FOUND)
   add_compile_definitions(HAVE_VOLK)
   link_directories(${VOLK_LIBRARY_DIRS})
+endif()
+
+# Project build options
+option(SIGUTILS_SINGLE_PRECISSION "Use single precission data types" 
+ON)
+if(SIGUTILS_SINGLE_PRECISSION)
+  add_compile_definitions(_SU_SINGLE_PRECISION)
 endif()
 
 # Source location
 set(SRCDIR   sigutils)
 set(UTILDIR  util)
 set(SPECDIR  ${SRCDIR}/specific)
-
-# Compiler configuration
-add_compile_definitions(_SU_SINGLE_PRECISION)
-
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,6 @@ project(
 
 include(FindPkgConfig)
 
-# Make sure CMAKE_INSTALL_LIBDIR is defined for all systems
-if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-  set(CMAKE_INSTALL_LIBDIR lib)
-endif()
-
 # Find requirements
 find_package(Threads)
 pkg_check_modules(SNDFILE REQUIRED sndfile>=1.0.2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,17 +35,20 @@ project(
   VERSION ${SIGUTILS_VERSION}
   LANGUAGES C)
 
+# CMake modules
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 include(FindPkgConfig)
+include(CodeAnalysis)
 
 # Find requirements
 find_package(Threads)
 pkg_check_modules(SNDFILE REQUIRED sndfile>=1.0.2)
 pkg_check_modules(FFTW3   REQUIRED fftw3f>=3.0)
 pkg_check_modules(VOLK              volk>=1.0)
-
-# Find cppcheck (if available)
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
-include(CodeAnalysis)
+if(VOLK_FOUND)
+  add_compile_definitions(HAVE_VOLK)
+  link_directories(${VOLK_LIBRARY_DIRS})
+endif()
 
 # Source location
 set(SRCDIR   sigutils)
@@ -54,10 +57,7 @@ set(SPECDIR  ${SRCDIR}/specific)
 
 # Compiler configuration
 add_compile_definitions(_SU_SINGLE_PRECISION)
-if(VOLK_FOUND)
-  add_compile_definitions(HAVE_VOLK)
-  link_directories(${VOLK_LIBRARY_DIRS})
-endif()
+
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 #
   
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12.0)
 
 set(SIGUTILS_VERSION_MAJOR 0)
 set(SIGUTILS_VERSION_MINOR 3)
@@ -58,9 +58,9 @@ set(UTILDIR  util)
 set(SPECDIR  ${SRCDIR}/specific)
 
 # Compiler configuration
-set(SIGUTILS_CONFIG_CFLAGS   "-D_SU_SINGLE_PRECISION")
+add_compile_definitions(_SU_SINGLE_PRECISION)
 if(VOLK_FOUND)
-  set(SIGUTILS_CONFIG_CFLAGS "${SIGUTILS_CONFIG_CFLAGS} -DHAVE_VOLK=1")
+  add_compile_definitions(HAVE_VOLK)
   link_directories(${VOLK_LIBRARY_DIRS})
 endif()
 
@@ -71,7 +71,6 @@ MinSizeRel."
        FORCE )
 endif()
 
-set(CMAKE_C_FLAGS          "${CMAKE_C_FLAGS} ${SIGUTILS_CONFIG_CFLAGS}")
 
 # The following hack exposes __FILENAME__ to source files as the relative
 # path of each source file.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The sigutils library is a digital signal processing library written in C, designed for blind signal analysis and automatic demodulation in GNU/Linux.
 
 ## Requirements and dependencies
-**sigutils** has been tested in GNU/Linux (i386, x86_64 and armhf), but it will probably work in many other architectures as well. CMake 3.7.2 or higher is required for the build. The following libraries (along with their respective development files) must also be present:
+**sigutils** has been tested in GNU/Linux (i386, x86_64 and armhf), but it will probably work in many other architectures as well. CMake 3.12.0 or higher is required for the build. The following libraries (along with their respective development files) must also be present:
 
 * sndfile (1.0.2 or later)
 * fftw3 (3.0 or later)
@@ -18,7 +18,12 @@ Just clone it from the GitHub repository:
 ```
 
 ## Building and installing sigutils
-First, you must create a build directory and configure it with:
+Example Archlinux depency installation:
+```
+sudo pacman -S libsndfile fftw libvolk
+```
+
+After, you must create a build directory and configure it with:
 
 ```
 % mkdir build


### PR DESCRIPTION
Work in progress: Do not merge!

I am planning on working a bit on the build system (I am assuming CMake is preferred and will not change in the foreseeable future, just let me know if you plan on changing it...).

Changes:
- Use the newer `add_compile_definitions` instead of directly passing compiler options. Improves compiler compatibility.
- Bump CMake version to 3.12.0 (required for `add_compile_definitions`).
- Removed unneded CMAKE_INSTALL_LIBDIR var setting (for version 3.12.0 the default value is `lib` unless overriden by the user).
- Expose precision selection as an option.