### PR TITLE
Remove ugly CMake hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(FindPkgConfig)
 include(CodeAnalysis)
 include(GitVersionDetect)
+include(RelativeFileMacro)
 
 # Use git version detect to obtain a version
 set(SIGUTILS_VERSION_MAJOR ${GITVERSIONDETECT_VERSION_MAJOR})
@@ -82,11 +83,6 @@ if (DEFINED PKGVERSION)
   # to set PKGVERSION to some descriptive string.
   add_compile_definitions(SIGUTILS_PKGVERSION="${PKGVERSION}")
 endif()
-
-# General CMake hacks
-# The following hack exposes __FILENAME__ to source files as the relative
-# path of each source file.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 
 # Source location
 set(SRCDIR   sigutils)
@@ -234,6 +230,8 @@ add_library(
   ${SIGUTILS_LIB_SOURCES}
   ${SIGUTILS_LIB_HEADERS}
   ${SIGUTILS_SPECIFIC_SOURCES})
+
+target_add_relative_file_macro(sigutils)
   
 set_property(TARGET sigutils PROPERTY VERSION   ${SIGUTILS_VERSION})
 set_property(TARGET sigutils PROPERTY SOVERSION ${SIGUTILS_ABI_VERSION})

--- a/cmake/modules/GitVersionDetect.cmake
+++ b/cmake/modules/GitVersionDetect.cmake
@@ -1,3 +1,34 @@
+# Distributed under the GPL v3 License. 
+
+#[=======================================================================[.rst:
+GitVersionDetect
+-------
+
+Derives a program version from Git tags. Only tags starting with a "v" will be
+used for version inference.
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``GITVERSIONDETECT_VERSION``
+  Full git tag as git describe --dirty would produce.
+``GITVERSIONDETECT_VERSION_MAJOR``
+  Major version matched from GITVERSIONDETECT_VERSION.
+``GITVERSIONDETECT_VERSION_MINOR``
+  Minor version matched from GITVERSIONDETECT_VERSION.
+``GITVERSIONDETECT_VERSION_PATCH``
+  Patch version matched from GITVERSIONDETECT_VERSION.
+``GITVERSIONDETECT_VERSION_COMMIT_NUM``
+  Number of commits that separate current source from the detected version
+  tag.
+``GITVERSIONDETECT_VERSION_COMMIT_SHA``
+  Latest commit sha.
+
+#]=======================================================================]
+
 # Required packages
 find_package(Git)
 

--- a/cmake/modules/RelativeFileMacro.cmake
+++ b/cmake/modules/RelativeFileMacro.cmake
@@ -1,0 +1,47 @@
+# Distributed under the GPL v3 License. 
+
+#[=======================================================================[.rst:
+RelativeFileMacro
+-------
+
+This module attempts to define the __REL_FILE__ macro as the relative paths
+of a file.
+
+This module requires CMake 3.20 or newer.
+
+Custom functions
+^^^^^^^^^^^^^^^^
+
+``source_add_relative_file_macro``
+  Add a __REL_FILE__ macro definition a source file.
+``target_add_relative_file_macro``
+  Add a __REL_FILE__ macro definition to all sources in the provided target.
+
+
+#]=======================================================================]
+
+# Function that sets the __REL_FILE__ definition for a particular source file
+function(source_add_relative_file_macro SRC_FILE_VAR)
+    # Get the real src file path
+    set(SRC_FILE ${${SRC_FILE_VAR}})
+    # Test if the provided path is relative
+    cmake_path(IS_RELATIVE SRC_FILE_VAR SRC_FILE_IS_REL)
+    if(SRC_FILE_IS_REL)
+        set(SRC_FILE_REL "\"${SRC_FILE}\"")
+    else()
+        # Get relative path
+        # Handles non normalized paths and mixed platform paths :)
+        cmake_path(RELATIVE_PATH ${SRC_FILE_VAR} BASE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_VARIABLE SRC_FILE_REL)
+        set(SRC_FILE_REL "\"${SRC_FILE}\"")
+    endif()
+    # Set a __FILE__ property for the current source file
+    set_property(SOURCE ${SRC_FILE} APPEND PROPERTY COMPILE_DEFINITIONS __REL_FILE__=${SRC_FILE_REL})
+endfunction()
+
+# Function that sets the __REL_FILE__ definition in all files of a particular target
+function(target_add_relative_file_macro TARGET)
+    get_target_property(TARGET_SRCS ${TARGET} SOURCES)
+    foreach(SRC ${TARGET_SRCS})
+        source_add_relative_file_macro(SRC)
+    endforeach()
+endfunction()

--- a/sigutils/defs.h
+++ b/sigutils/defs.h
@@ -98,12 +98,20 @@
 #define SU_DESTRUCT(class, dest) JOIN(class, _finalize)(dest)
 #define SU_DISPOSE(class, dest) JOIN(class, _destroy)(dest)
 
+/* __REL_FILE__ is provided byt the build system, use it.
+  Otherwise, set the variable to an empty string as we
+  don't want to leak full paths into the binary.
+*/
+#ifndef __REL_FILE__
+#  define __REL_FILE__ ""
+#endif /* __REL_FILE__ */
+
 #define SU_TRYCATCH(expr, action)        \
   if (!(expr)) {                         \
     SU_ERROR(                            \
         "exception in \"%s\" (%s:%d)\n", \
         STRINGIFY(expr),                 \
-        __FILENAME__,                    \
+        __REL_FILE__,                    \
         __LINE__);                       \
     action;                              \
   }

--- a/sigutils/log.h
+++ b/sigutils/log.h
@@ -70,12 +70,8 @@ struct sigutils_log_config {
         NULL,    /* log_func */         \
   }
 
-#ifndef __FILENAME__
-#  define __FILENAME__ "(no file)"
-#endif /* __FILENAME__ */
-
 #ifndef SU_LOG_DOMAIN
-#  define SU_LOG_DOMAIN __FILENAME__
+#  define SU_LOG_DOMAIN __REL_FILE__
 #endif /* SU_LOG_DOMAIN */
 
 #define SU_ERROR(fmt, arg...) \


### PR DESCRIPTION
Sorry, it had to go sooner or later...

See: https://discourse.cmake.org/t/cmake-file-name-in-a-portable-way/6918

The hack was not portable. That means that only worked with Makefiles as the CMake backend. That means that Ninja backend cannot be used. That means that MSYS will probably won't accept a PR with this package (https://github.com/msys2/MINGW-packages/pull/10543#issuecomment-1012312383). Therefore the hack is ugly...

I don't like embedding full paths in binaries for many reasons. I've tryed to avoid that by using the new __FILE_NAME__ macro available in GCC 12 and newer. If not available, the full path is used...