### PR TITLE
Add Cmake module as part of the installation/packaging

### DIFF
--- a/cmake/sigutilsConfig.cmake.in
+++ b/cmake/sigutilsConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+
+check_required_components("@PROJECT_NAME@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,7 @@ target_add_relative_file_macro(sigutils)
 # Add public include directories
 target_include_directories(sigutils
         INTERFACE $<INSTALL_INTERFACE:include>
-        PRIVATE ${CMAKE_SOURCE_DIR}/include/)
+        PRIVATE ${CMAKE_SOURCE_DIR}/src/include/)
 
 # Extra compilation definitions
 if(SIGUTILS_SINGLE_PRECISSION)
@@ -93,6 +93,7 @@ endif()
 # Target properties
 set_property(TARGET sigutils PROPERTY VERSION   ${SIGUTILS_VERSION})
 set_property(TARGET sigutils PROPERTY SOVERSION ${SIGUTILS_ABI_VERSION})
+set_property(TARGET sigutils PROPERTY EXPORT_NAME ${PROJECT_NAME})
 
 # Target dependencies
 target_link_libraries(sigutils ${SNDFILE_LIBRARIES})
@@ -150,7 +151,7 @@ write_basic_package_version_file(
         COMPATIBILITY SameMajorVersion)
 
 install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/sigutlsConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/sigutilsConfig.cmake
         ${CMAKE_BINARY_DIR}/sigutilsConfigVersion.cmake
         DESTINATION ${INSTALL_EXPORTS_DIR}
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,9 @@ add_library(sigutils SHARED ${SRCS})
 target_add_relative_file_macro(sigutils)
 
 # Add public include directories
-target_include_directories(sigutils PUBLIC include/)
+target_include_directories(sigutils
+        INTERFACE $<INSTALL_INTERFACE:include>
+        PRIVATE ${CMAKE_SOURCE_DIR}/include/)
 
 # Extra compilation definitions
 if(SIGUTILS_SINGLE_PRECISSION)
@@ -110,9 +112,49 @@ endif()
 target_pc_file_generate(sigutils "Digital signal processing utility library")
 
 # File install
-install(TARGETS sigutils LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT LIB)
+install(TARGETS sigutils
+        EXPORT sigutils-export
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT LIB)
+
 install(DIRECTORY include/sigutils DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT DEVEL)
+
 install(FILES ${PROJECT_BINARY_DIR}/src/sigutils.pc DESTINATION ${CMAKE_INSTALL_PKGCONFIGDIR} COMPONENT DEVEL)
+
+set(INSTALL_EXPORTS_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT sigutils-export
+        FILE sigutilsTargets.cmake
+        NAMESPACE sigutils::
+        DESTINATION ${INSTALL_EXPORTS_DIR}
+        )
+
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+        ${CMAKE_SOURCE_DIR}/cmake/sigutilsConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/sigutilsConfig.cmake
+        INSTALL_DESTINATION ${INSTALL_EXPORTS_DIR}
+        PATH_VARS INCLUDE_INSTALL_DIR)
+
+write_basic_package_version_file(
+        ${CMAKE_BINARY_DIR}/sigutilsConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion)
+
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/sigutlsConfig.cmake
+        ${CMAKE_BINARY_DIR}/sigutilsConfigVersion.cmake
+        DESTINATION ${INSTALL_EXPORTS_DIR}
+        )
+
 
 # General packaging settings
 set(CPACK_PACKAGE_NAME sigutils)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Catch2)
 if(Catch2_FOUND)
     # General options
     file(GLOB_RECURSE TEST_SRCS LIST_DIRECTORIES false *.cpp)
-    add_executable(sigutils_test EXCLUDE_FROM_ALL ${TEST_SRCS})
+    add_executable(sigutils_test EXCLUDE_FROM_ALL ${TEST_SRCS} cmake_tests/test.c)
     target_include_directories(sigutils_test PUBLIC $<TARGET_PROPERTY:sigutils,INCLUDE_DIRECTORIES>)
     target_compile_definitions(sigutils_test PUBLIC $<TARGET_PROPERTY:sigutils,COMPILE_DEFINITIONS>)
     target_link_libraries(sigutils_test $<TARGET_LINKER_FILE:sigutils>)

--- a/tests/cmake_tests/CMakeLists.txt
+++ b/tests/cmake_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20.0)
+project(testCmakeSigUtils)
+
+find_package(sigutils REQUIRED)
+
+add_executable(testCmakeSigUtils test.c)
+
+target_link_libraries(testCmakeSigUtils sigutils::sigutils)

--- a/tests/cmake_tests/test.c
+++ b/tests/cmake_tests/test.c
@@ -1,0 +1,17 @@
+//
+// Created by happycactus on 20/06/23.
+//
+
+#include <sigutils/sigutils.h>
+#include <sigutils/version.h>
+
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+  su_lib_init();
+
+  printf("Testing sigutils version: %08x ABI: %d\n", SIGUTILS_VERSION, SIGUTILS_ABI_VERSION);
+
+  return 0;
+}


### PR DESCRIPTION
This PR packages the library with cmake files, allowing CMake projects to automatically find it and configure the compilation and linking.
It also adds a test project in a subdirectory of the test directory. Once installed, the installation can be tested by building the test project with cmake.

