### PR TITLE
Optimize FFT calculations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ set_property(TARGET sigutils PROPERTY SOVERSION ${SIGUTILS_ABI_VERSION})
 # Target dependencies
 target_link_libraries(sigutils ${SNDFILE_LIBRARIES})
 target_link_libraries(sigutils ${FFTW3_LIBRARIES})
+target_link_libraries(sigutils fftw3f_threads)
 target_link_libraries(sigutils ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(sigutils m)
 

--- a/src/include/sigutils/sigutils.h
+++ b/src/include/sigutils/sigutils.h
@@ -37,5 +37,7 @@ SUBOOL su_lib_save_wisdom(void);
 
 /* Internal */
 int su_lib_fftw_strategy(void);
+SU_FFTW(_plan) su_lib_plan_dft_1d(int n, SU_FFTW(_complex) *in,
+        SU_FFTW(_complex) *out, int sign, unsigned flags);
 
 #endif /* _SIGUTILS_SIGUTILS_H */

--- a/src/sigutils/detect.c
+++ b/src/sigutils/detect.c
@@ -451,7 +451,7 @@ SU_INSTANCER(
   SU_ALLOCATE_MANY_FAIL(new->_r_alloc, params->window_size, SUFLOAT);
 
   /* Direct FFT plan */
-  if ((new->fft_plan = SU_FFTW(_plan_dft_1d)(
+  if ((new->fft_plan = su_lib_plan_dft_1d(
            params->window_size,
            new->window,
            new->fft,
@@ -492,7 +492,7 @@ SU_INSTANCER(
 
       memset(new->ifft, 0, params->window_size * sizeof(SU_FFTW(_complex)));
 
-      if ((new->fft_plan_rev = SU_FFTW(_plan_dft_1d)(
+      if ((new->fft_plan_rev = su_lib_plan_dft_1d(
                params->window_size,
                new->fft,
                new->ifft,

--- a/src/sigutils/lib.c
+++ b/src/sigutils/lib.c
@@ -22,10 +22,12 @@
 #define SU_LOG_LEVEL "lib"
 
 #include <sigutils/sigutils.h>
+#include <pthread.h>
 
 SUPRIVATE SUBOOL su_log_cr = SU_TRUE;
 SUPRIVATE SUBOOL su_measure_ffts = SU_FALSE;
 SUPRIVATE char *su_wisdom_file = NULL;
+SUPRIVATE pthread_mutex_t fft_plan_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 SUPRIVATE char
 su_log_severity_to_char(enum sigutils_log_severity sev)
@@ -140,9 +142,12 @@ su_lib_plan_dft_1d(int n, SU_FFTW(_complex) *in, SU_FFTW(_complex) *out,
   else
     nthreads = 4;
 
+  if (pthread_mutex_lock(&fft_plan_mutex) == -1)
+    return NULL;
   SU_FFTW(_plan_with_nthreads)(nthreads);
   plan = SU_FFTW(_plan_dft_1d)(n, in, out, sign, flags);
   SU_FFTW(_plan_with_nthreads)(1);
+  pthread_mutex_unlock(&fft_plan_mutex);
 
   return plan;
 }

--- a/src/sigutils/lib.c
+++ b/src/sigutils/lib.c
@@ -126,6 +126,27 @@ su_lib_fftw_strategy(void)
   return su_measure_ffts ? FFTW_MEASURE : FFTW_ESTIMATE;
 }
 
+SU_FFTW(_plan)
+su_lib_plan_dft_1d(int n, SU_FFTW(_complex) *in, SU_FFTW(_complex) *out,
+        int sign, unsigned flags)
+{
+  SU_FFTW(_plan) plan;
+  int nthreads;
+
+  if (n < 32768)
+    nthreads = 1;
+  else if (n == 32768)
+    nthreads = 2;
+  else
+    nthreads = 4;
+
+  SU_FFTW(_plan_with_nthreads)(nthreads);
+  plan = SU_FFTW(_plan_dft_1d)(n, in, out, sign, flags);
+  SU_FFTW(_plan_with_nthreads)(1);
+
+  return plan;
+}
+
 SUBOOL
 su_lib_init_ex(const struct sigutils_log_config *logconfig)
 {
@@ -135,6 +156,9 @@ su_lib_init_ex(const struct sigutils_log_config *logconfig)
     logconfig = &su_lib_log_config;
 
   su_log_init(logconfig);
+
+  SU_FFTW(_init_threads)();
+  SU_FFTW(_make_planner_thread_safe)();
 
   return SU_TRUE;
 }

--- a/src/sigutils/smoothpsd.c
+++ b/src/sigutils/smoothpsd.c
@@ -229,7 +229,7 @@ SU_METHOD(
     memset(fftbuf, 0, params->fft_size * sizeof(SU_FFTW(_complex)));
 
     /* Direct FFT plan */
-    if ((fft_plan = SU_FFTW(_plan_dft_1d)(
+    if ((fft_plan = su_lib_plan_dft_1d(
              params->fft_size,
              fftbuf,
              fftbuf,

--- a/src/sigutils/smoothpsd.c
+++ b/src/sigutils/smoothpsd.c
@@ -86,7 +86,6 @@ SU_METHOD(su_smoothpsd, SUBOOL, feed, const SUCOMPLEX *data, SUSCOUNT size)
 {
   unsigned int chunk;
   unsigned int i;
-  unsigned int p;
   SUBOOL mutex_acquired = SU_FALSE;
   SUBOOL ok = SU_FALSE;
 
@@ -154,15 +153,16 @@ SU_METHOD(su_smoothpsd, SUBOOL, feed, const SUCOMPLEX *data, SUSCOUNT size)
 
         /* Time to trigger FFT! */
         if (self->fft_p >= self->max_p) {
+          unsigned int copy_cnt = self->params.fft_size - self->p;
           self->fft_p = 0;
-          p = self->p;
+
+          /* put ring buffer time domain IQ data in sequential order */
+          memcpy(self->fft, self->buffer + self->p, copy_cnt * sizeof(SUCOMPLEX));
+          memcpy(self->fft + copy_cnt, self->buffer, self->p * sizeof(SUCOMPLEX));
 
           /* Apply window function */
-          for (i = 0; i < self->params.fft_size; ++i) {
-            self->fft[i] = self->buffer[p++] * self->window_func[i];
-            if (p >= self->params.fft_size)
-              p = 0;
-          }
+          for (i = 0; i < self->params.fft_size; ++i)
+            self->fft[i] *= self->window_func[i];
 
           SU_TRY(su_smoothpsd_exec_fft(self));
         }

--- a/src/sigutils/specific/apt.c
+++ b/src/sigutils/specific/apt.c
@@ -501,7 +501,7 @@ su_apt_decoder_new(SUFLOAT fs, const struct sigutils_apt_decoder_callbacks *cb)
   bw = SU_ABS2NORM_FREQ(fs, SU_APT_AM_BANDWIDTH);
 
   SU_TRYCATCH(
-      pattern_plan = SU_FFTW(_plan_dft_1d)(
+      pattern_plan = su_lib_plan_dft_1d(
           SU_APT_BUFF_LEN,
           new->sync_fft,
           new->sync_fft,
@@ -510,7 +510,7 @@ su_apt_decoder_new(SUFLOAT fs, const struct sigutils_apt_decoder_callbacks *cb)
       goto done);
 
   SU_TRYCATCH(
-      new->direct_plan = SU_FFTW(_plan_dft_1d)(
+      new->direct_plan = su_lib_plan_dft_1d(
           SU_APT_BUFF_LEN,
           new->samp_buffer,
           new->corr_fft,
@@ -519,7 +519,7 @@ su_apt_decoder_new(SUFLOAT fs, const struct sigutils_apt_decoder_callbacks *cb)
       goto done);
 
   SU_TRYCATCH(
-      new->reverse_plan = SU_FFTW(_plan_dft_1d)(
+      new->reverse_plan = su_lib_plan_dft_1d(
           SU_APT_BUFF_LEN,
           new->corr_fft,
           new->corr_fft,

--- a/src/sigutils/specttuner.c
+++ b/src/sigutils/specttuner.c
@@ -139,7 +139,7 @@ SU_METHOD_CONST(
 
   /* Backward plan */
   SU_TRY(
-      channel->forward = SU_FFTW(_plan_dft_1d)(
+      channel->forward = su_lib_plan_dft_1d(
           window_size,
           channel->h,
           channel->h,
@@ -148,7 +148,7 @@ SU_METHOD_CONST(
 
   /* Forward plan */
   SU_TRY(
-      channel->backward = SU_FFTW(_plan_dft_1d)(
+      channel->backward = su_lib_plan_dft_1d(
           window_size,
           channel->h,
           channel->h,
@@ -437,7 +437,7 @@ SU_INSTANCER(
       new->size * sizeof(SU_FFTW(_complex)));
 
   SU_TRY_FAIL(
-      new->plan[SU_SPECTTUNER_STATE_EVEN] = SU_FFTW(_plan_dft_1d)(
+      new->plan[SU_SPECTTUNER_STATE_EVEN] = su_lib_plan_dft_1d(
           new->size,
           new->fft,
           new->ifft[SU_SPECTTUNER_STATE_EVEN],
@@ -445,7 +445,7 @@ SU_INSTANCER(
           su_lib_fftw_strategy()));
 
   SU_TRY_FAIL(
-      new->plan[SU_SPECTTUNER_STATE_ODD] = SU_FFTW(_plan_dft_1d)(
+      new->plan[SU_SPECTTUNER_STATE_ODD] = su_lib_plan_dft_1d(
           new->size,
           new->fft,
           new->ifft[SU_SPECTTUNER_STATE_ODD],
@@ -528,7 +528,7 @@ SU_INSTANCER(su_specttuner, const struct sigutils_specttuner_params *params)
 
   if (new->params.early_windowing) {
     SU_TRY_FAIL(
-        new->plans[SU_SPECTTUNER_STATE_EVEN] = SU_FFTW(_plan_dft_1d)(
+        new->plans[SU_SPECTTUNER_STATE_EVEN] = su_lib_plan_dft_1d(
             params->window_size,
             new->fft,
             new->fft,
@@ -536,7 +536,7 @@ SU_INSTANCER(su_specttuner, const struct sigutils_specttuner_params *params)
             su_lib_fftw_strategy()));
 
     SU_TRY_FAIL(
-        new->plans[SU_SPECTTUNER_STATE_ODD] = SU_FFTW(_plan_dft_1d)(
+        new->plans[SU_SPECTTUNER_STATE_ODD] = su_lib_plan_dft_1d(
             params->window_size,
             new->fft,
             new->fft,
@@ -545,7 +545,7 @@ SU_INSTANCER(su_specttuner, const struct sigutils_specttuner_params *params)
   } else {
     /* Even plan starts at the beginning of the window */
     SU_TRY_FAIL(
-        new->plans[SU_SPECTTUNER_STATE_EVEN] = SU_FFTW(_plan_dft_1d)(
+        new->plans[SU_SPECTTUNER_STATE_EVEN] = su_lib_plan_dft_1d(
             params->window_size,
             new->buffer,
             new->fft,
@@ -554,7 +554,7 @@ SU_INSTANCER(su_specttuner, const struct sigutils_specttuner_params *params)
 
     /* Odd plan stars at window_size / 2 */
     SU_TRY_FAIL(
-        new->plans[SU_SPECTTUNER_STATE_ODD] = SU_FFTW(_plan_dft_1d)(
+        new->plans[SU_SPECTTUNER_STATE_ODD] = su_lib_plan_dft_1d(
             params->window_size,
             new->buffer + new->half_size,
             new->fft,


### PR DESCRIPTION
Use multiple threads for large FFT sizes, and volk-ify hot loops. Needs `fftwf_init_threads()` to be called before sigutils is used (perhaps from `suscan_sigutils_init()`).